### PR TITLE
API response message structure is inconsistent

### DIFF
--- a/src/main/java/com/untzuntz/ustackserver/server/ServerHandler.java
+++ b/src/main/java/com/untzuntz/ustackserver/server/ServerHandler.java
@@ -564,7 +564,7 @@ public class ServerHandler extends SimpleChannelUpstreamHandler {
 					{
 						APIException apiErr = (APIException)ierr.getCause();
 						logger.warn(String.format("%s [%s] API Exception => %s", callInstance.params.getRemoteIpAddress(), callInstance.path, apiErr));
-						APIResponse.httpError(callInstance.ctx.getChannel(), APIResponse.error(apiErr.toDBObject()), callInstance.req, HttpResponseStatus.BAD_REQUEST, callInstance.params);
+						APIResponse.httpError(callInstance.ctx.getChannel(), APIResponse.error(apiErr.toDBObject(), apiErr.getMessage()), callInstance.req, HttpResponseStatus.BAD_REQUEST, callInstance.params);
 					}
 					else
 					{

--- a/src/main/java/com/untzuntz/ustackserverapi/APIResponse.java
+++ b/src/main/java/com/untzuntz/ustackserverapi/APIResponse.java
@@ -223,22 +223,22 @@ public class APIResponse {
 	
 	public static DBObject getResponseObject(String status, String msg)
 	{
-		DBObject obj = new BasicDBObject();
-		DBObject result = new BasicDBObject();
-		obj.put("apiResult", result);
-		result.put("status", status);
-		if (msg != null)	
-			result.put("message", msg);
-
-		return obj;
+		return getResponseObject(status, null, msg);
 	}
-	
+
 	public static DBObject getResponseObject(String status, DBObject ret)
+	{
+		return getResponseObject(status, ret, null);
+	}
+
+	public static DBObject getResponseObject(String status, DBObject ret, String msg)
 	{
 		DBObject obj = new BasicDBObject();
 		DBObject result = new BasicDBObject();
 		obj.put("apiResult", result);
 		result.put("status", status);
+		if (msg != null)
+			result.put("message", msg);
 		if (ret != null)	
 			obj.putAll(ret);
 
@@ -251,6 +251,10 @@ public class APIResponse {
 	
 	public static DBObject error(DBObject ret) {
 		return getResponseObject("ERROR", ret);
+	}
+
+	public static DBObject error(DBObject ret, String msg) {
+		return getResponseObject("ERROR", ret, msg);
 	}
 	
 	public static DBObject success(String msg) {


### PR DESCRIPTION
Current response structure for errors could be like so:

```{
  "type" : "BadRequestException",
  "message" : "Not on Beta List",
  "apiResult" : {
    "status" : "ERROR"
}```

Or like so:

```{
  "type" : "BadRequestException",
  "apiResult" : {
    "status" : "ERROR",
    "message" : "Not on Beta List"
}```

This PR ensures that the `message` is nested under `apiResult`.